### PR TITLE
Scaling argument for exp and retract, docs, tangent vector tests

### DIFF
--- a/src/ManifoldMuseum.jl
+++ b/src/ManifoldMuseum.jl
@@ -113,7 +113,13 @@ vector_transport(M::Manifold, x, v, y) = vector_transport!(M, copy(v), x, y, v)
 random_point(M::Manifold) = error("Not implemented")
 random_tangent_vector(M::Manifold, x) = error("Not implemented")
 
+"""
+    injectivity_radius(M::Manifold, x)
+
+Distance such that `log(M, x, y)` is defined for all points within this radius.
+"""
 injectivity_radius(M::Manifold, x) = 1.0
+
 zero_tangent_vector(M::Manifold, x) = log(M, x, x)
 zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 

--- a/src/ManifoldMuseum.jl
+++ b/src/ManifoldMuseum.jl
@@ -13,7 +13,7 @@ export dimension,
     norm,
     retract,
     retract!,
-    typical_distance,
+    injectivity_radius,
     zero_tangent_vector,
     zero_tangent_vector!
 
@@ -113,7 +113,7 @@ vector_transport(M::Manifold, x, v, y) = vector_transport!(M, copy(v), x, y, v)
 random_point(M::Manifold) = error("Not implemented")
 random_tangent_vector(M::Manifold, x) = error("Not implemented")
 
-typical_distance(M::Manifold) = 1.0
+injectivity_radius(M::Manifold, x) = 1.0
 zero_tangent_vector(M::Manifold, x) = log(M, x, x)
 zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 

--- a/src/ManifoldMuseum.jl
+++ b/src/ManifoldMuseum.jl
@@ -45,7 +45,9 @@ Retraction (cheaper, approximate version of exponential map) of tangent
 vector `t*v` at point `x` from manifold `M`.
 Result is saved to `y`.
 """
-retract!(M::Manifold, y, x, v, t=1) = exp!(M, y, x, v, t)
+retract!(M::Manifold, y, x, v) = exp!(M, y, x, v)
+
+retract!(M::Manifold, y, x, v, t) = retract!(M, y, x, t*v)
 
 """
     retract(M::Manifold, x, v, t=1)
@@ -53,19 +55,21 @@ retract!(M::Manifold, y, x, v, t=1) = exp!(M, y, x, v, t)
 Retraction (cheaper, approximate version of exponential map) of tangent
 vector `t*v` at point `x` from manifold `M`.
 """
-retract(M::Manifold, x, v, t=1) = retract!(M, copy(x), x, v, t)
+retract(M::Manifold, x, v) = retract!(M, similar(x), x, v)
+
+retract(M::Manifold, x, v, t) = retract(M, x, t*v)
 
 project_tangent!(M::Manifold, w, x, v) = error("Not implemented")
 project_tangent(M::Manifold, x, v) = project_tangent!(M, copy(x), x, v)
 
-distance(M::Manifold, x, y) = error("Not implemented")
+distance(M::Manifold, x, y) = norm(M, x, log(M, x, y))
 
 """
     dot(M::Manifold, x, v, w)
 
 Inner product of tangent vectors `v` and `w` at point `x` from manifold `M`.
 """
-dot(M::Manifold, x, v, w) = dot(v, w)
+dot(M::Manifold, x, v, w) = error("Not implemented")
 
 """
     norm(M::Manifold, x, v)
@@ -80,14 +84,18 @@ norm(M::Manifold, x, v) = sqrt(dot(M, x, v, v))
 Exponential map of tangent vector `t*v` at point `x` from manifold `M`.
 Result is saved to `y`.
 """
-exp!(M::Manifold, y, x, v, t=1) = error("Not implemented")
+exp!(M::Manifold, y, x, v, t) = exp!(M::Manifold, y, x, t*v)
+
+exp!(M::Manifold, y, x, v) = error("Not implemented")
 
 """
     exp(M::Manifold, x, v, t=1)
 
 Exponential map of tangent vector `t*v` at point `x` from manifold `M`.
 """
-exp(M::Manifold, x, v, t=1) = exp!(M, copy(x), x, v, t)
+exp(M::Manifold, x, v) = exp!(M, similar(x), x, v)
+
+exp(M::Manifold, x, v, t) = exp(M, x, t*v)
 
 log!(M::Manifold, v, x, y) = error("Not implemented")
 

--- a/src/ManifoldMuseum.jl
+++ b/src/ManifoldMuseum.jl
@@ -3,24 +3,91 @@ module ManifoldMuseum
 import Base: isapprox, exp, log
 import LinearAlgebra: dot, norm
 
+export Manifold
+export dimension,
+    distance,
+    dot,
+    exp!,
+    geodesic,
+    log!,
+    norm,
+    retract,
+    retract!,
+    typical_distance,
+    zero_tangent_vector,
+    zero_tangent_vector!
 
 abstract type Manifold end
 
-isapprox(m::Manifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
+"""
+    isapprox(M::Manifold, x, y; kwargs...)
 
-retract!(M::Manifold, y, x, v) = exp!(M, y, x, v)
-retract(M::Manifold, x, v) = retract!(M, copy(x), x, v)
+Check if points `x` and `y` from manifold `M` are approximately equal.
+
+Keyword arguments can be used to specify tolerances.
+"""
+isapprox(M::Manifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
+
+"""
+    isapprox(M::Manifold, x, v, w; kwargs...)
+
+Check if vectors `v` and `w` tangent at `x` from manifold `M` are
+approximately equal.
+
+Keyword arguments can be used to specify tolerances.
+"""
+isapprox(M::Manifold, x, v, w; kwargs...) = isapprox(v, w; kwargs...)
+
+"""
+    retract!(M::Manifold, y, x, v, t=1)
+
+Retraction (cheaper, approximate version of exponential map) of tangent
+vector `t*v` at point `x` from manifold `M`.
+Result is saved to `y`.
+"""
+retract!(M::Manifold, y, x, v, t=1) = exp!(M, y, x, v, t)
+
+"""
+    retract(M::Manifold, x, v, t=1)
+
+Retraction (cheaper, approximate version of exponential map) of tangent
+vector `t*v` at point `x` from manifold `M`.
+"""
+retract(M::Manifold, x, v, t=1) = retract!(M, copy(x), x, v, t)
 
 project_tangent!(M::Manifold, w, x, v) = error("Not implemented")
 project_tangent(M::Manifold, x, v) = project_tangent!(M, copy(x), x, v)
 
 distance(M::Manifold, x, y) = error("Not implemented")
 
+"""
+    dot(M::Manifold, x, v, w)
+
+Inner product of tangent vectors `v` and `w` at point `x` from manifold `M`.
+"""
 dot(M::Manifold, x, v, w) = dot(v, w)
+
+"""
+    norm(M::Manifold, x, v)
+
+Norm of tangent vector `v` at point `x` from manifold `M`.
+"""
 norm(M::Manifold, x, v) = sqrt(dot(M, x, v, v))
 
-exp!(M::Manifold, y, x, v) = error("Not implemented")
-exp(M::Manifold, x, v) = exp!(M,copy(x), x, v)
+"""
+    exp!(M::Manifold, y, x, v, t=1)
+
+Exponential map of tangent vector `t*v` at point `x` from manifold `M`.
+Result is saved to `y`.
+"""
+exp!(M::Manifold, y, x, v, t=1) = error("Not implemented")
+
+"""
+    exp(M::Manifold, x, v, t=1)
+
+Exponential map of tangent vector `t*v` at point `x` from manifold `M`.
+"""
+exp(M::Manifold, x, v, t=1) = exp!(M, copy(x), x, v, t)
 
 log!(M::Manifold, v, x, y) = error("Not implemented")
 
@@ -45,21 +112,6 @@ zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 geodesic(M::Manifold, x, y, t) = exp(M, x, log(M, x, y), t)
 
 include("Sphere.jl")
-
-export Manifold
-export dimension,
-    distance,
-    dot,
-    exp,
-    exp!,
-    geodesic,
-    isapprox,
-    log,
-    log!,
-    norm,
-    typical_distance,
-    zero_tangent_vector,
-    zero_tangent_vector!
 
 
 end # module

--- a/src/Sphere.jl
+++ b/src/Sphere.jl
@@ -2,16 +2,17 @@ struct Sphere{T} <: Manifold where {T}
     shape::T
 end
 
+dot(S::Sphere, x, w, v) = dot(w, v)
+
 project_tangent!(S::Sphere, w, x, v) = (w .= v .- dot(x, v).*x)
 distance(S::Sphere, x, y) = acos(dot(x, y))
 
-function exp!(S::Sphere, y, x, v, t=1)
-    scaled_v = t*v
-    nv = norm(S, x, scaled_v)
+function exp!(S::Sphere, y, x, v)
+    nv = norm(S, x, v)
     if nv ≈ 0.0
         y .= x
     else
-        y .= cos(nv).*x .+ (sin(nv)/nv).*scaled_v
+        y .= cos(nv).*x .+ (sin(nv)/nv).*v
     end
     return y
 end

--- a/src/Sphere.jl
+++ b/src/Sphere.jl
@@ -5,12 +5,13 @@ end
 project_tangent!(S::Sphere, w, x, v) = (w .= v .- dot(x, v).*x)
 distance(S::Sphere, x, y) = acos(dot(x, y))
 
-function exp!(S::Sphere, y, x, v)
-    nv = norm(S, x, v)
+function exp!(S::Sphere, y, x, v, t=1)
+    scaled_v = t*v
+    nv = norm(S, x, scaled_v)
     if nv ≈ 0.0
         y .= x
     else
-        y .= cos(nv).*x .+ (sin(nv)/nv).*v
+        y .= cos(nv).*x .+ (sin(nv)/nv).*scaled_v
     end
     return y
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,11 @@ function test_manifold(M::Manifold, pts::AbstractVector)
     @test isapprox(tv1, zero_tangent_vector(M, pts[1]))
     log!(M, tv1, pts[1], pts[2])
     @test norm(M, pts[1], tv1) ≈ sqrt(dot(M, pts[1], tv1, tv1))
+
+    @test isapprox(M, exp(M, pts[1], tv1, 1), pts[2])
+    @test isapprox(M, exp(M, pts[1], tv1, 0), pts[1])
+    @test isapprox(M, pts[1], 0*tv1, zero_tangent_vector(M, pts[1]))
+    @test isapprox(M, pts[1], 2*tv1, tv1+tv1)
 end
 
 @testset "Sphere" begin


### PR DESCRIPTION
I've made a few new changes:

* `isapprox` for tangent vectors,
* scaling argument for `exp` and `retract`,
* some docs,
* new tests for tangent vectors,
* `log`, `exp` and `isapprox` are not explicitly exported (they don't have to be).